### PR TITLE
added possibility of ensemble with one shift

### DIFF
--- a/src/baskerville/seqnn.py
+++ b/src/baskerville/seqnn.py
@@ -219,12 +219,12 @@ class SeqNN:
 
     def build_ensemble(self, ensemble_rc: bool = False, ensemble_shifts=[0]):
         """Build ensemble of models computing on augmented input sequences."""
-        if ensemble_rc or len(ensemble_shifts) > 1:
+        if ensemble_rc or len(ensemble_shifts) > 1 or int(ensemble_shifts[0]) != 0:
             # sequence input
             sequence = tf.keras.Input(shape=(self.seq_length, 4), name="sequence")
             sequences = [sequence]
 
-            if len(ensemble_shifts) > 1:
+            if len(ensemble_shifts) > 1 or int(ensemble_shifts[0]) != 0:
                 # generate shifted sequences
                 sequences = layers.EnsembleShift(ensemble_shifts)(sequences)
 


### PR DESCRIPTION
### Description of your changes
When building the ensemble in the build_ensemble() module of seqnn.py, an ensemble shift array with one non-zero shift will be ignored as only its length is checked and not the contents

### Type of change
- Bug fix (non-breaking change which fixes an issue)
