### PR TITLE
Stitch

### DIFF
--- a/src/baskerville/scripts/hound_snp.py
+++ b/src/baskerville/scripts/hound_snp.py
@@ -77,11 +77,12 @@ def main():
         help="Ensemble prediction shifts [Default: %default]",
     )
     parser.add_option(
-        "--stitch", 
+        "--stitch",
         dest="stitch",
-        default=False, 
+        default=False,
         action="store_true",
-        help=" [Default: %default]")
+        help=" [Default: %default]",
+    )
     parser.add_option(
         "--stats",
         dest="snp_stats",

--- a/src/baskerville/scripts/hound_snp.py
+++ b/src/baskerville/scripts/hound_snp.py
@@ -76,7 +76,8 @@ def main():
         type="str",
         help="Ensemble prediction shifts [Default: %default]",
     )
-    parser.add_option("--stitch", 
+    parser.add_option(
+        "--stitch", 
         dest="stitch",
         default=False, 
         action="store_true",

--- a/src/baskerville/scripts/hound_snp.py
+++ b/src/baskerville/scripts/hound_snp.py
@@ -76,6 +76,11 @@ def main():
         type="str",
         help="Ensemble prediction shifts [Default: %default]",
     )
+    parser.add_option("--stitch", 
+        dest="stitch",
+        default=False, 
+        action="store_true",
+        help=" [Default: %default]")
     parser.add_option(
         "--stats",
         dest="snp_stats",

--- a/src/baskerville/snps.py
+++ b/src/baskerville/snps.py
@@ -228,7 +228,7 @@ def score_snps(params_file, model_file, vcf_file, worker_index, options):
                 )
                 alt_preds = np.repeat(alt_preds, repeats=2, axis=0)
                 alt_preds = list(alt_preds)
-                
+
             # flip reference and alternate
             if snps[si].flipped:
                 rp_snp = np.array(alt_preds)


### PR DESCRIPTION
### Description of your changes
Add --stitch option to the indel scoring calculation in hound_snp. Deals with ensemble shifts. 
Stacks alt_preds twofold and repeats them again to mathc the ref_preds dimension.

### Type of change
- [x] New feature
   - [x] Backwards compatible
